### PR TITLE
Update role to use openstack.cloud.server_info

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,13 +19,13 @@
 - name: alert if dot is not installed
   assert:
     that: osggraphercmd_out.rc == 0
-    msg: "dot (from graphviz) has to be installed to use this role"  
+    msg: "dot (from graphviz) has to be installed to use this role"
 
 - name: Get instances information
-  os_server_facts:
-    validate_certs: false
+  openstack.cloud.server_info:
     cloud: "{{ osggrapherCloudInfra }}"
   tags: instance
+  register: result
   when: osggrapherShowInstances
 
 - name: Get security groups and rules

--- a/templates/fullsg-instances.dot.j2
+++ b/templates/fullsg-instances.dot.j2
@@ -12,7 +12,7 @@ digraph G {
       label = <<table border="0" cellspacing="0">
                   <tr><td ><b>{{ sg.name }}</b></td></tr>
                   <tr><td ><i>Servers</i></td></tr>
-{%           for MyServer in openstack_servers %}
+{%           for MyServer in result.openstack_servers %}
 {%               if MyServer.security_groups | selectattr('name','equalto', sg.name) | list | first is defined %}
                   <tr><td border="1" bgcolor="gray">{{ MyServer.name }}</td></tr>
 {%               endif %}


### PR DESCRIPTION
The ansible module used to retrieve information was called os_server_facts before Ansible 2.9, returning ansible_facts. It was renamed to openstack.cloud.server_info and no longer returns ansible_facts. 

Tested and working on Ansible 2.10.4